### PR TITLE
Change bevy-inspector-egui ver to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ parking_lot = "0.11.2"
 
 bevy = { version = "0.6", default-features = false, features = ["render"] }
 
-bevy-inspector-egui = { version = "0.7", default-features = false }
+bevy-inspector-egui = { version = "0.8", default-features = false }


### PR DESCRIPTION
Updates the required version of bevy-inspector-egui to 0.8. Checked that it compiles fine.