### PR TITLE
Fix build on git version of bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ parking_lot = "0.11.2"
 
 bevy = { version = "0.6", default-features = false, features = ["render"] }
 
-bevy-inspector-egui = { version = "0.7", default-features = false }
+bevy-inspector-egui = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ parking_lot = "0.11.2"
 
 bevy = { version = "0.6", default-features = false, features = ["render"] }
 
-bevy-inspector-egui = { version = "0.8", default-features = false }
+bevy-inspector-egui = { git = "https://github.com/jakobhellermann/bevy-inspector-egui", rev = "f02c9d8fb43f1debc45f0e90f481ab828314ceec" default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ parking_lot = "0.11.2"
 
 bevy = { version = "0.6", default-features = false, features = ["render"] }
 
-bevy-inspector-egui = { git = "https://github.com/jakobhellermann/bevy-inspector-egui", rev = "f02c9d8fb43f1debc45f0e90f481ab828314ceec" default-features = false }
+bevy-inspector-egui = { git = "https://github.com/jakobhellermann/bevy-inspector-egui", rev = "f02c9d8", default-features = false }


### PR DESCRIPTION
Updates dependant version of bevy-inspector-egui to latest commit as of writing this. This version compiles against current git ver of bevy.